### PR TITLE
make footer links easier to click using padding

### DIFF
--- a/src/main.sass
+++ b/src/main.sass
@@ -152,11 +152,10 @@ pre
 
 #footer
   position: fixed
-  width: 360px
-  height: 26px
-  line-height: 26px
   bottom: 0
   right: 0
+  padding-left: 20px
+  padding-right: 20px
   background-color: black
   opacity: 0.8
   color: white
@@ -165,9 +164,12 @@ pre
   -webkit-opacity: 1
   -moz-opacity: 1  
   a
+    height: 26px
+    line-height: 26px
+    padding-left: 23px
+    padding-right: 23px
     color: #ccc
     text-decoration: none
-    margin-left: 45px
     &:hover
       text-decoration: underline
 


### PR DESCRIPTION
Now, clicking the area around the links will trigger the nearest link. This makes the buttons easier to click, and less annoying.

These styles are still not perfect. In Firefox, the whitespace in the HTML adds unclickable space between the links. And there is some extra unclickable space below the links, too. You would probably need to use floats, along with the clearfix, to fix these problems. That’s too big a change for me to make in the GitHub editor. But at least these styles are better than before – the footer looks very similar, but the links are easier to click.
